### PR TITLE
Fix name to follow k8s constraint

### DIFF
--- a/templates/jupyter-pod/main.tf
+++ b/templates/jupyter-pod/main.tf
@@ -229,7 +229,7 @@ resource "coder_app" "jupyter" {
 resource "kubernetes_pod" "main" {
   count = data.coder_workspace.me.start_count
   metadata {
-    name      = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+    name      = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
     namespace = "coder"
   }
   spec {
@@ -275,7 +275,7 @@ resource "kubernetes_pod" "main" {
 
 resource "kubernetes_persistent_volume_claim" "home-directory" {
   metadata {
-    name      = "home-coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+    name      = "home-coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
     namespace = "coder"
   }
   wait_until_bound = false


### PR DESCRIPTION
The names of our Users are capitalized, which raises issues with the naming constraints of k8s.
To make sure the constraints are met, we have to lowercase the owner when creating a name.